### PR TITLE
✨ feat: 블로그 상세 페이지 목차 기능 추가

### DIFF
--- a/app/blog/[category]/[slug]/page.tsx
+++ b/app/blog/[category]/[slug]/page.tsx
@@ -3,8 +3,9 @@ import type { JSX } from 'react';
 import { notFound } from 'next/navigation';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 
-import { getPostBySlug } from '@internal/lib/blog';
 import { MDXComponents } from '@internal/components/mdx-components';
+import { getPostBySlug, extractTableOfContents } from '@internal/lib/blog';
+import { TableOfContents } from '@internal/components/toc/table-of-contents';
 
 interface PostPageProps {
   params: Promise<{
@@ -25,19 +26,32 @@ export default async function PostPage({
     return null;
   }
 
+  // 마크다운 콘텐츠에서 목차 추출
+  const tableOfContents = await extractTableOfContents(post.content);
+
   return (
-    <article className="max-w-4xl mx-auto py-12 px-4">
-      <header className="mb-8">
-        <h1 className="text-4xl font-bold mb-2">{post.title}</h1>
-        <div className="flex items-center text-sm text-gray-500">
-          <span>{new Date(post.date).toLocaleDateString()}</span>
-          <span className="mx-2">•</span>
-          <span className="capitalize">{post.category}</span>
+    <div className="container mx-auto py-12 px-4">
+      <div className="flex flex-col lg:flex-row gap-8">
+        {/* 목차 - 넓은 화면에서만 표시 */}
+        <div className="hidden lg:block lg:sticky lg:top-28 lg:self-start">
+          <TableOfContents toc={tableOfContents} />
         </div>
-      </header>
-      <div className="prose prose-lg max-w-none">
-        <MDXRemote components={MDXComponents} source={post.content} />
+
+        {/* 본문 내용 */}
+        <article className="flex-1 max-w-4xl mx-auto">
+          <header className="mb-8">
+            <h1 className="text-4xl font-bold mb-2">{post.title}</h1>
+            <div className="flex items-center text-sm text-gray-500">
+              <span>{new Date(post.date).toLocaleDateString()}</span>
+              <span className="mx-2">•</span>
+              <span className="capitalize">{post.category}</span>
+            </div>
+          </header>
+          <div className="prose prose-lg max-w-none">
+            <MDXRemote components={MDXComponents} source={post.content} />
+          </div>
+        </article>
       </div>
-    </article>
+    </div>
   );
 }

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -129,4 +129,94 @@ export const MDXComponents = {
       </Link>
     );
   },
+  h1: ({ children }: { children: React.ReactNode }): JSX.Element => {
+    const id =
+      typeof children === 'string'
+        ? children
+            .toLowerCase()
+            .replace(/[^\w\s가-힣]/g, '')
+            .replace(/\s+/g, '-')
+        : '';
+
+    return (
+      <h1 id={id} className="scroll-mt-20">
+        {children}
+      </h1>
+    );
+  },
+  h2: ({ children }: { children: React.ReactNode }): JSX.Element => {
+    const id =
+      typeof children === 'string'
+        ? children
+            .toLowerCase()
+            .replace(/[^\w\s가-힣]/g, '')
+            .replace(/\s+/g, '-')
+        : '';
+
+    return (
+      <h2 id={id} className="scroll-mt-20">
+        {children}
+      </h2>
+    );
+  },
+  h3: ({ children }: { children: React.ReactNode }): JSX.Element => {
+    const id =
+      typeof children === 'string'
+        ? children
+            .toLowerCase()
+            .replace(/[^\w\s가-힣]/g, '')
+            .replace(/\s+/g, '-')
+        : '';
+
+    return (
+      <h3 id={id} className="scroll-mt-20">
+        {children}
+      </h3>
+    );
+  },
+  h4: ({ children }: { children: React.ReactNode }): JSX.Element => {
+    const id =
+      typeof children === 'string'
+        ? children
+            .toLowerCase()
+            .replace(/[^\w\s가-힣]/g, '')
+            .replace(/\s+/g, '-')
+        : '';
+
+    return (
+      <h4 id={id} className="scroll-mt-20">
+        {children}
+      </h4>
+    );
+  },
+  h5: ({ children }: { children: React.ReactNode }): JSX.Element => {
+    const id =
+      typeof children === 'string'
+        ? children
+            .toLowerCase()
+            .replace(/[^\w\s가-힣]/g, '')
+            .replace(/\s+/g, '-')
+        : '';
+
+    return (
+      <h5 id={id} className="scroll-mt-20">
+        {children}
+      </h5>
+    );
+  },
+  h6: ({ children }: { children: React.ReactNode }): JSX.Element => {
+    const id =
+      typeof children === 'string'
+        ? children
+            .toLowerCase()
+            .replace(/[^\w\s가-힣]/g, '')
+            .replace(/\s+/g, '-')
+        : '';
+
+    return (
+      <h6 id={id} className="scroll-mt-20">
+        {children}
+      </h6>
+    );
+  },
 };

--- a/components/toc/table-of-contents.tsx
+++ b/components/toc/table-of-contents.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import type { TableOfContents as TOCType } from '@internal/lib/blog';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ListOrderedIcon } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+
+import { cn } from '@internal/lib/utils';
+
+interface TableOfContentsProps {
+  toc: TOCType[];
+  className?: string;
+}
+
+export function TableOfContents({ toc, className }: TableOfContentsProps) {
+  const pathname = usePathname();
+  const [activeId, setActiveId] = useState<string>('');
+
+  // 스크롤 위치에 따라 활성화된 헤더를 업데이트
+  useEffect(() => {
+    if (!toc.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: '0px 0px -80% 0px', threshold: 0.1 },
+    );
+
+    // 모든 헤더 요소 관찰
+    const observeHeaders = () => {
+      // 재귀적으로 헤더 ID 수집
+      const collectHeaderIds = (items: TOCType[]): string[] => {
+        return items.flatMap((item) => {
+          const ids = [item.id];
+
+          if (item.children?.length) {
+            ids.push(...collectHeaderIds(item.children));
+          }
+
+          return ids;
+        });
+      };
+
+      const ids = collectHeaderIds(toc);
+
+      ids.forEach((id) => {
+        const element = document.getElementById(id);
+
+        if (element) {
+          observer.observe(element);
+        }
+      });
+    };
+
+    // 약간의 지연 후 관찰 시작 (렌더링 완료를 보장)
+    const timer = setTimeout(observeHeaders, 100);
+
+    return () => {
+      clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [toc]);
+
+  // 목차가 비어있으면 렌더링하지 않음
+  if (!toc.length) {
+    return null;
+  }
+
+  const renderTOCItems = (items: TOCType[]) => {
+    return items.map((item) => (
+      <li key={item.id} className="mt-2">
+        <Link
+          href={`${pathname}#${item.id}`}
+          className={cn(
+            'block truncate transition-all hover:text-primary relative',
+            activeId === item.id
+              ? 'font-medium text-primary'
+              : 'text-muted-foreground',
+            // 계층 구조에 따른 스타일 차별화
+            item.level === 1 && 'text-base font-semibold',
+            item.level === 2 &&
+              'text-sm pl-5 before:content-["•"] before:absolute before:left-1 before:text-muted-foreground/70',
+            item.level === 3 &&
+              'text-xs pl-10 before:content-["◦"] before:absolute before:left-6 before:text-muted-foreground/60',
+            item.level === 4 &&
+              'text-xs pl-16 before:content-["▫"] before:absolute before:left-12 before:text-muted-foreground/50',
+            item.level >= 5 &&
+              'text-xs pl-20 before:content-["▪"] before:absolute before:left-16 before:text-muted-foreground/40',
+          )}
+        >
+          {item.text}
+        </Link>
+        {item.children?.length ? (
+          <ul className="mt-1 border-l border-l-slate-200 ml-2">
+            {renderTOCItems(item.children)}
+          </ul>
+        ) : null}
+      </li>
+    ));
+  };
+
+  return (
+    <div
+      className={cn(
+        'w-full max-w-[280px] bg-white border rounded-lg shadow-md',
+        className,
+      )}
+    >
+      <div className="bg-white rounded-lg overflow-hidden">
+        <div className="flex items-center gap-2 py-3 px-4 border-b bg-slate-50">
+          <ListOrderedIcon className="h-5 w-5 text-slate-600" />
+          <h3 className="text-sm font-medium text-slate-800">목차</h3>
+        </div>
+        <div className="p-4 max-h-[70vh] overflow-y-auto">
+          <ul className="space-y-2">{renderTOCItems(toc)}</ul>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 개요
블로그 상세 페이지에 목차 기능 추가. 긴 블로그 글 읽을 때 어디에 뭐가 있는지 쉽게 파악할 수 있게 만들었음.

## 주요 변경사항
- 마크다운 헤더들(h1~h6) 추출하는 함수 만듦
- MDX 헤더 컴포넌트에 자동으로 ID 넣어서 앵커 링크 지원하게 함
- 계층 구조 잘 보이는 목차 컴포넌트 구현
- 스크롤하면서 현재 보는 부분 하이라이팅 되게 만듦
- 블로그 상세 페이지 왼쪽에 목차 넣음

## 기술적 고려사항
- 목차는 클라이언트 컴포넌트로 구현 (스크롤 위치 감지 때문에)
- IntersectionObserver API로 현재 보고 있는 섹션 감지
- 마크다운 헤더 추출 함수는 서버 액션으로 구현
- 모바일에선 목차 안 보이고 넓은 화면에서만 보이게 함

## 테스트 결과
- 여러 글로 테스트해봤고 다 잘 됨
- 헤더 레벨별로 들여쓰기랑 스타일 적용 잘 됨
- 스크롤하면 현재 보는 부분 하이라이팅 제대로 작동함
- 모바일에선 목차 안 보이는 것 확인함

## 향후 개선점
- 모바일에서도 토글 버튼으로 목차 볼 수 있게 해보기
- 목차 접기/펼치기 기능 넣기
- 목차 위치 설정 기능 추가해보기

## 테스트 방법
1. 블로그 상세 페이지 들어가보기
2. 헤더 많은 글에서 목차 확인하기
3. 스크롤하면서 하이라이팅 잘 되는지 보기
4. 목차 항목 클릭해서 해당 위치로 이동하는지 확인하기

## 체크리스트
- [x] 코드 스타일 맞춤
- [ ] 테스트 코드는 아직 안 넣었음
- [ ] 문서 업데이트는 필요 없을 듯
- [x] 브라우저 호환성 문제 없음

## 기타 참고사항
쓰다가 불편한 점 있으면 추가로 개선하자! 오늘도 테스트코드 귀찮았지만 내일 쫘르르 할예정.
