### PR TITLE
✨ [시리즈] 블로그 시리즈 기능 구현

### DIFF
--- a/app/blog/life/simplicity-is-sophistication.mdx
+++ b/app/blog/life/simplicity-is-sophistication.mdx
@@ -6,6 +6,10 @@ koreanSlug: '단순화하여-생각할-수-있는가'
 status: 'done'
 priority: 'high'
 tags: ['철학', '개발방법론', '단순함', '코드품질', '생산성']
+series: 'art-of-simplicity'
+seriesTitle: '단순함의 기술'
+seriesDescription: '복잡한 개발 세계에서 단순함을 추구하는 방법론'
+seriesOrder: 1
 ---
 
 ## "복잡성은 당연하지 않다"

--- a/app/blog/tech/branch-condition-nightmare.mdx
+++ b/app/blog/tech/branch-condition-nightmare.mdx
@@ -6,6 +6,10 @@ koreanSlug: '분기처리-악몽에서-벗어나는-법'
 status: 'done'
 priority: 'high'
 tags: ['리액트', '패턴', '분기처리', '코드품질', '리팩토링']
+series: 'art-of-simplicity'
+seriesTitle: '단순함의 기술'
+seriesDescription: '복잡한 개발 세계에서 단순함을 추구하는 방법론'
+seriesOrder: 2
 ---
 
 ## 당신의 리액트 코드가 당신의 정신을 갉아먹고 있다: 분기처리의 함정

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,6 +1,8 @@
+import type { JSX } from 'react';
+
 import Link from 'next/link';
 
-export default function NotFound() {
+export default function NotFound(): JSX.Element {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8 text-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,9 @@ async function getPostsAsTableData(): Promise<z.infer<typeof tableSchema>[]> {
       tags: post.tags || [],
       readingTime: post.readingTime || 5,
       series: post.series || undefined,
+      seriesTitle: post.seriesTitle || undefined,
+      seriesDescription: post.seriesDescription || undefined,
+      seriesOrder: post.seriesOrder || undefined,
     })),
   );
 }

--- a/components/table-view/columns.tsx
+++ b/components/table-view/columns.tsx
@@ -109,13 +109,14 @@ export const columns: ColumnDef<TableData>[] = [
     ),
     cell: ({ row }): ReactNode => {
       const series = row.getValue('series');
+      const seriesTitle = row.original.seriesTitle;
 
       return (
         <div className="flex items-center">
           {series ? (
             <>
               <BookOpen className="mr-2 h-4 w-4 text-muted-foreground" />
-              <span>{String(series)}</span>
+              <span>{seriesTitle || String(series)}</span>
             </>
           ) : (
             <span className="text-muted-foreground">-</span>

--- a/components/table-view/data-table-faceted-filter.tsx
+++ b/components/table-view/data-table-faceted-filter.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import type { JSX } from 'react';
+import type { LucideIcon } from 'lucide-react';
 import type { Column } from '@tanstack/react-table';
 
 import { Check, PlusCircle } from 'lucide-react';
@@ -28,14 +31,16 @@ interface DataTableFacetedFilterProps<TData, TValue> {
   options: {
     label: string;
     value: string;
-    icon?: React.ComponentType<{ className?: string }>;
+    icon: LucideIcon;
   }[];
+  onValueChange?: (value: string[]) => void;
 }
 
 export function DataTableFacetedFilter<TData, TValue>({
   column,
   title,
   options,
+  onValueChange,
 }: DataTableFacetedFilterProps<TData, TValue>): JSX.Element {
   const facets = column?.getFacetedUniqueValues();
   const selectedValues = new Set(column?.getFilterValue() as string[]);
@@ -104,6 +109,9 @@ export function DataTableFacetedFilter<TData, TValue>({
                       column?.setFilterValue(
                         filterValues.length ? filterValues : undefined,
                       );
+                      if (onValueChange) {
+                        onValueChange(filterValues);
+                      }
                     }}
                   >
                     <div
@@ -134,7 +142,12 @@ export function DataTableFacetedFilter<TData, TValue>({
                 <CommandSeparator />
                 <CommandGroup>
                   <CommandItem
-                    onSelect={() => column?.setFilterValue(undefined)}
+                    onSelect={() => {
+                      column?.setFilterValue(undefined);
+                      if (onValueChange) {
+                        onValueChange([]);
+                      }
+                    }}
                     className="justify-center text-center"
                   >
                     필터 초기화

--- a/components/table-view/data-table-toolbar.tsx
+++ b/components/table-view/data-table-toolbar.tsx
@@ -3,14 +3,24 @@
 import type { JSX } from 'react';
 import type { Table } from '@tanstack/react-table';
 
+import type { Post } from '@internal/lib/blog';
+
 import { X } from 'lucide-react';
+import { useEffect, useCallback, useMemo } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { BookOpen, Tag, Clock, FolderOpen } from 'lucide-react';
 
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
 import { DataTableViewOptions } from './data-table-view-options';
 import { DataTableFacetedFilter } from './data-table-faceted-filter';
-import { categories, postSeries, postTags, readingTimes } from './data';
+
+interface FilterOption {
+  label: string;
+  value: string;
+  icon: typeof BookOpen | typeof Tag | typeof Clock | typeof FolderOpen;
+}
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
@@ -19,7 +29,131 @@ interface DataTableToolbarProps<TData> {
 export function DataTableToolbar<TData>({
   table,
 }: DataTableToolbarProps<TData>): JSX.Element {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const isFiltered = table.getState().columnFilters.length > 0;
+
+  // 실제 데이터에서 필터 옵션 생성
+  const filterOptions = useMemo(() => {
+    const data = table
+      .getCoreRowModel()
+      .rows.map((row) => row.original) as Post[];
+
+    // 카테고리 옵션
+    const categories: FilterOption[] = Array.from(
+      new Set(data.map((item) => item.category)),
+    ).map((category) => ({
+      label: category,
+      value: category,
+      icon: FolderOpen,
+    }));
+
+    // 시리즈 옵션
+    const seriesMap = new Map<string, string>();
+
+    data.forEach((item) => {
+      if (item.series) {
+        if (item.seriesTitle) {
+          seriesMap.set(item.series, item.seriesTitle);
+        }
+      }
+    });
+
+    const series: FilterOption[] = Array.from(seriesMap.entries()).map(
+      ([id, title]) => {
+        return {
+          label: title,
+          value: id,
+          icon: BookOpen,
+        };
+      },
+    );
+
+    // 태그 옵션
+    const tags: FilterOption[] = Array.from(
+      new Set(data.flatMap((item) => item.tags || [])),
+    ).map((tag) => ({
+      label: tag,
+      value: tag,
+      icon: Tag,
+    }));
+
+    // 읽기 시간 옵션
+    const readingTimes: FilterOption[] = Array.from(
+      new Set(
+        data
+          .filter((item) => item.readingTime)
+          .map((item) => Math.floor((item.readingTime || 0) / 5) * 5),
+      ),
+    )
+      .sort((a, b) => a - b)
+      .map((time) => ({
+        label: `${time}-${time + 4}분`,
+        value: time.toString(),
+        icon: Clock,
+      }));
+
+    return {
+      categories,
+      series,
+      tags,
+      readingTimes,
+    };
+  }, [table]);
+
+  // URL 파라미터를 테이블 필터에 적용하는 함수
+  const applyUrlParamsToFilter = useCallback(
+    (params: URLSearchParams, table: Table<TData>) => {
+      const title = params.get('title');
+      const category = params.get('category');
+      const series = params.get('series');
+      const tags = params.get('tags');
+      const readingTime = params.get('readingTime');
+
+      if (title) {
+        table.getColumn('title')?.setFilterValue(title);
+      }
+      if (category) {
+        table.getColumn('category')?.setFilterValue([category]);
+      }
+      if (series) {
+        table.getColumn('series')?.setFilterValue([series]);
+      }
+      if (tags) {
+        table.getColumn('tags')?.setFilterValue(tags.split(','));
+      }
+      if (readingTime) {
+        table.getColumn('readingTime')?.setFilterValue([readingTime]);
+      }
+    },
+    [],
+  );
+
+  // URL 파라미터를 테이블 필터에 적용
+  useEffect(() => {
+    applyUrlParamsToFilter(searchParams, table);
+  }, [searchParams, table, applyUrlParamsToFilter]);
+
+  // 필터 변경을 URL에 반영
+  const updateURL = useCallback(
+    (columnId: string, value: string[]) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      if (value.length) {
+        params.set(columnId, value.join(','));
+      } else {
+        params.delete(columnId);
+      }
+
+      // 빈 필터는 URL에서 제거
+      if (!Array.from(params.values()).some(Boolean)) {
+        router.push('/', { scroll: false });
+      } else {
+        router.push(`/?${params.toString()}`, { scroll: false });
+      }
+    },
+    [router, searchParams],
+  );
 
   return (
     <div className="flex items-center justify-between">
@@ -27,43 +161,62 @@ export function DataTableToolbar<TData>({
         <Input
           placeholder="제목 검색..."
           value={(table.getColumn('title')?.getFilterValue() as string) ?? ''}
-          onChange={(event) =>
-            table.getColumn('title')?.setFilterValue(event.target.value)
-          }
+          onChange={(event) => {
+            const value = event.target.value;
+
+            table.getColumn('title')?.setFilterValue(value);
+            const params = new URLSearchParams(searchParams.toString());
+
+            if (value) {
+              params.set('title', value);
+            } else {
+              params.delete('title');
+            }
+            router.push(params.toString() ? `/?${params.toString()}` : '/', {
+              scroll: false,
+            });
+          }}
           className="h-8 w-[150px] lg:w-[250px]"
         />
         {table.getColumn('category') && (
           <DataTableFacetedFilter
             column={table.getColumn('category')}
             title="카테고리"
-            options={categories}
+            options={filterOptions.categories}
+            onValueChange={(value) => updateURL('category', value)}
           />
         )}
         {table.getColumn('series') && (
           <DataTableFacetedFilter
             column={table.getColumn('series')}
             title="시리즈"
-            options={postSeries}
+            options={filterOptions.series}
+            onValueChange={(value) => updateURL('series', value)}
           />
         )}
         {table.getColumn('tags') && (
           <DataTableFacetedFilter
             column={table.getColumn('tags')}
             title="태그"
-            options={postTags}
+            options={filterOptions.tags}
+            onValueChange={(value) => updateURL('tags', value)}
           />
         )}
         {table.getColumn('readingTime') && (
           <DataTableFacetedFilter
             column={table.getColumn('readingTime')}
             title="읽기 시간"
-            options={readingTimes}
+            options={filterOptions.readingTimes}
+            onValueChange={(value) => updateURL('readingTime', value)}
           />
         )}
         {isFiltered && (
           <Button
             variant="ghost"
-            onClick={() => table.resetColumnFilters()}
+            onClick={() => {
+              table.resetColumnFilters();
+              router.push('/', { scroll: false });
+            }}
             className="h-8 px-2 lg:px-3"
           >
             초기화

--- a/components/table-view/data-table.tsx
+++ b/components/table-view/data-table.tsx
@@ -77,7 +77,7 @@ export function DataTable<TData, TValue>({
   });
 
   // 블로그 포스트 페이지로 이동하는 함수
-  const navigateToPost = (row: Row<TData>) => {
+  const navigateToPost = (row: Row<TData>): void => {
     // 타입 단언을 사용하여 TableData로 변환
     const data = row.original as unknown as TableData;
 

--- a/components/table-view/schema.ts
+++ b/components/table-view/schema.ts
@@ -11,6 +11,9 @@ export const tableSchema = z.object({
   tags: z.array(z.string()).optional(),
   readingTime: z.number().optional(),
   series: z.string().optional().nullable(),
+  seriesTitle: z.string().optional(),
+  seriesDescription: z.string().optional(),
+  seriesOrder: z.number().optional(),
 });
 
 export type TableData = z.infer<typeof tableSchema>;

--- a/components/toc/series-of-contents.tsx
+++ b/components/toc/series-of-contents.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import type { JSX } from 'react';
+
+import type { TableOfContents as TOCType } from '@internal/lib/blog';
+
+import Link from 'next/link';
+import React, { useState } from 'react';
+import { BookOpenIcon } from 'lucide-react';
+
+import { cn } from '@internal/lib/utils';
+
+interface SeriesOfContentsProps {
+  toc: TOCType[];
+  className?: string;
+  title?: string;
+  seriesId?: string;
+}
+
+export function SeriesOfContents({
+  toc,
+  className,
+  title = '시리즈 목록',
+  seriesId,
+}: SeriesOfContentsProps): JSX.Element | null {
+  const [mounted, setMounted] = useState<boolean>(false);
+
+  // 클라이언트 사이드에서만 실행되도록 마운트 상태 관리
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // 목차가 비어있으면 렌더링하지 않음
+  if (!toc.length) {
+    return null;
+  }
+
+  const renderTOCItems = (items: TOCType[]): JSX.Element[] => {
+    return items.map((item) => {
+      // 시리즈 제목(level 1)인 경우 메인 페이지로 이동하면서 시리즈 필터링
+      const href = item.level === 1 ? `/?series=${seriesId}` : `#${item.id}`;
+
+      return (
+        <li key={item.id} className={cn('mt-2', item.level === 1 && 'mt-4')}>
+          <Link
+            href={href}
+            className={cn(
+              'inline-block no-underline transition-colors hover:text-foreground',
+              item.level === 1
+                ? 'text-foreground font-semibold'
+                : 'text-muted-foreground font-normal',
+            )}
+          >
+            {item.text}
+          </Link>
+          {item.children && item.children.length > 0 && (
+            <ul className="ml-4 border-l text-sm">
+              {renderTOCItems(item.children)}
+            </ul>
+          )}
+        </li>
+      );
+    });
+  };
+
+  if (!mounted) {
+    return <div className={className} />;
+  }
+
+  return (
+    <div className={className}>
+      <div className="flex items-center gap-2 font-semibold">
+        <BookOpenIcon className="h-5 w-5" />
+        <span>{title}</span>
+      </div>
+      <ul className="mt-4">{renderTOCItems(toc)}</ul>
+    </div>
+  );
+}

--- a/components/toc/table-of-contents.tsx
+++ b/components/toc/table-of-contents.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { JSX } from 'react';
+
 import type { TableOfContents as TOCType } from '@internal/lib/blog';
 
 import Link from 'next/link';
@@ -12,9 +14,14 @@ import { cn } from '@internal/lib/utils';
 interface TableOfContentsProps {
   toc: TOCType[];
   className?: string;
+  title?: string;
 }
 
-export function TableOfContents({ toc, className }: TableOfContentsProps) {
+export function TableOfContents({
+  toc,
+  className,
+  title = '목차',
+}: TableOfContentsProps): JSX.Element | null {
   const pathname = usePathname();
   const [activeId, setActiveId] = useState<string>('');
   const [mounted, setMounted] = useState<boolean>(false);
@@ -40,7 +47,7 @@ export function TableOfContents({ toc, className }: TableOfContentsProps) {
     );
 
     // 모든 헤더 요소 관찰
-    const observeHeaders = () => {
+    const observeHeaders = (): void => {
       // 재귀적으로 헤더 ID 수집
       const collectHeaderIds = (items: TOCType[]): string[] => {
         return items.flatMap((item) => {
@@ -68,7 +75,7 @@ export function TableOfContents({ toc, className }: TableOfContentsProps) {
     // 약간의 지연 후 관찰 시작 (렌더링 완료를 보장)
     const timer = setTimeout(observeHeaders, 100);
 
-    return () => {
+    return (): void => {
       clearTimeout(timer);
       observer.disconnect();
     };
@@ -80,7 +87,7 @@ export function TableOfContents({ toc, className }: TableOfContentsProps) {
   }
 
   // 목차 아이템 렌더링 함수
-  const renderTOCItems = (items: TOCType[]) => {
+  const renderTOCItems = (items: TOCType[]): JSX.Element[] => {
     return items.map((item) => (
       <li key={item.id} className="mt-2">
         <Link
@@ -123,13 +130,13 @@ export function TableOfContents({ toc, className }: TableOfContentsProps) {
       <div className="bg-white rounded-lg overflow-hidden">
         <div className="flex items-center gap-2 py-3 px-4 border-b bg-slate-50">
           <ListOrderedIcon className="h-5 w-5 text-slate-600" />
-          <h3 className="text-sm font-medium text-slate-800">목차</h3>
+          <h3 className="text-sm font-medium text-slate-800">{title}</h3>
         </div>
         <div className="p-4 max-h-[70vh] overflow-y-auto">
           {mounted ? (
             <ul className="space-y-2">{renderTOCItems(toc)}</ul>
           ) : (
-            <div className="text-sm text-gray-500">목차 로딩 중...</div>
+            <div className="text-sm text-gray-500">{title} 로딩 중...</div>
           )}
         </div>
       </div>

--- a/lib/series.ts
+++ b/lib/series.ts
@@ -1,0 +1,82 @@
+import type { Post, TableOfContents } from './blog';
+
+export interface SeriesPost {
+  title: string;
+  slug: string;
+  category: string;
+  koreanSlug?: string;
+  order: number;
+}
+
+export interface Series {
+  id: string;
+  title: string;
+  description?: string;
+  posts: SeriesPost[];
+}
+
+/**
+ * 시리즈 포스트 목록을 TOC 형식으로 변환하는 함수
+ */
+export function convertSeriesToTOC(
+  series: Series,
+  currentPostSlug?: string,
+): TableOfContents[] {
+  // 시리즈 제목을 최상위 항목으로 추가
+  const seriesTOC: TableOfContents[] = [
+    {
+      id: `series-${series.id}`,
+      text: series.title,
+      level: 1,
+      children: series.posts
+        .sort((a, b) => a.order - b.order)
+        .map((post) => {
+          const slug = post.koreanSlug || post.slug;
+
+          return {
+            id: `series-post-${slug}`,
+            text: post.title,
+            level: 2,
+            // 현재 포스트인 경우 특별한 메타데이터 추가
+            metadata: {
+              isCurrentPost: currentPostSlug === slug,
+              url: `/blog/${post.category}/${slug}`,
+            },
+          };
+        }),
+    },
+  ];
+
+  return seriesTOC;
+}
+
+/**
+ * 포스트 목록에서 특정 시리즈에 속한 포스트들을 찾아서 Series 객체로 변환하는 함수
+ */
+export function extractSeriesFromPosts(
+  posts: Post[],
+  seriesId: string,
+): Series | null {
+  // 해당 시리즈의 포스트들 찾기
+  const seriesPosts = posts.filter((post) => post.series === seriesId);
+
+  if (seriesPosts.length === 0) {
+    return null;
+  }
+
+  // 시리즈의 첫 번째 포스트에서 시리즈 메타데이터 가져오기
+  const firstPost = seriesPosts[0];
+
+  return {
+    id: seriesId,
+    title: firstPost.seriesTitle || seriesId,
+    description: firstPost.seriesDescription,
+    posts: seriesPosts.map((post) => ({
+      title: post.title,
+      slug: post.slug,
+      category: post.category,
+      koreanSlug: post.koreanSlug,
+      order: post.seriesOrder || 0,
+    })),
+  };
+}


### PR DESCRIPTION
## 작업 내용
오늘은 블로그 시리즈 기능을 구현했다. 시리즈로 묶인 포스트들을 쉽게 탐색할 수 있게 하는 게 목표였는데, 
생각보다 타입 문제가 많이 발생해서 시간이 좀 걸렸다.

### 1. 타입 시스템 개선
- `metadata` 필드가 `Record<string, unknown>`으로 되어있어서 타입 안전성이 떨어졌다
- `SeriesMetadata` 타입을 새로 만들어서 시리즈 관련 정보를 명확하게 정의했다
- 테이블 스키마도 같이 업데이트했다

### 2. 새로운 기능
- 시리즈 목차 컴포넌트를 새로 만들었다 (`SeriesOfContents`)
- 시리즈 관련 유틸리티 함수들도 추가
- 메인 페이지에서 시리즈로 필터링할 수 있게 했다

### 3. 리팩토링
- 테이블 필터링 로직이 너무 복잡해서 함수로 분리했다
- URL 파라미터 처리하는 부분도 깔끔하게 정리
- 타입 안전성 강화하면서 몇 가지 버그도 잡았다

### 4. 스타일 개선
- 404 페이지 타입 추가
- 필터 UI 좀 더 깔끔하게 수정

### 5. 콘텐츠
- MDX 파일들 frontmatter 형식 새로 바꿨다
- 시리즈 메타데이터 추가

## 다음에 할 것
- [ ] 시리즈 전용 페이지 만들기
- [ ] 시리즈마다 썸네일 이미지 추가
- [ ] 시리즈 진행률 표시하기
- [ ] 시리즈 설명 페이지 디자인 개선

## 메모
- frontmatter 형식이 바뀌어서 앞으로 포스트 쓸 때 주의해야 함
- 시리즈 기능은 일단 기본적인 것만 구현했고, 나중에 더 발전시킬 예정
- 타입 문제는 해결했지만, 나중에 더 개선할 여지가 있음

## 테스트한 것
- 시리즈 필터 잘 되는지 확인
- URL로 필터링 되는지 확인
- 시리즈 목차 네비게이션 확인
- 기존 기능들 안 깨졌는지 체크